### PR TITLE
Fix: Stabilize CI/CD and Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,9 +109,8 @@ jobs:
 
       - name: Run all tests with coverage
         run: |
-          pytest tests/unit/api_gateway/ -v \
+          pytest tests/ -v \
             --cov=services --cov-report=xml --cov-report=term-missing
-        continue-on-error: true
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,9 @@ jobs:
           cache: 'pip'
 
       - name: Install dependencies
-        run: pip install -r requirements-dev.txt numpy pytest pytest-asyncio
+        run: |
+          pip install -r requirements-dev.txt numpy pytest pytest-asyncio
+          pip install -r services/vision_service/requirements.txt
 
       - name: Run tests
         run: pytest tests/unit/vision_service/ -v --tb=short -m "not slow" --cov=services/vision_service/src --cov-report=xml
@@ -106,6 +108,7 @@ jobs:
         run: |
           pip install -r requirements-dev.txt
           pip install -r services/api_gateway/requirements.txt
+          pip install -r services/vision_service/requirements.txt
 
       - name: Run all tests with coverage
         run: |

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,12 +2,10 @@
 testpaths = tests
 
 addopts =
-    -v
     --strict-markers
     --tb=short
-    --cov=services
-    --cov-report=term-missing
-
+    -p no:warnings
+    --show-capture=no
 markers =
     unit: Unit tests
     integration: Integration tests

--- a/services/api_gateway/src/schemas/prediction.py
+++ b/services/api_gateway/src/schemas/prediction.py
@@ -94,6 +94,9 @@ class WordPredictionResponse(BaseModel):
 class BufferStatsResponse(BaseModel):
     """Response for buffer statistics."""
 
-    buffer_size: int = Field(..., description="Current buffer size")
-    phrase_length: int = Field(..., description="Current phrase word count")
+    total_received: int = Field(..., description="Total received predictions")
+    total_accepted: int = Field(..., description="Total accepted predictions")
+    rejected_by_cooldown: int = Field(..., description="Rejected by cooldown")
+    rejected_by_confidence: int = Field(..., description="Rejected by low confidence")
+    acceptance_rate: float = Field(..., description="Acceptance rate percentage")
     current_phrase: str = Field(..., description="Current accumulated phrase")

--- a/services/vision_service/requirements.txt
+++ b/services/vision_service/requirements.txt
@@ -23,9 +23,7 @@ python-multipart==0.0.21
 joblib==1.5.3
 protobuf==3.20.3
 sounddevice==0.5.5
-<<<<<<< HEAD
 prometheus-client==0.19.0
-=======
 
 # Para entrenar MSG3D
 torch>=2.0.0
@@ -35,4 +33,3 @@ pyyaml>=6.0
 tqdm>=4.65.0
 tensorboard>=2.13.0
 scipy>=1.10.0
->>>>>>> feature/holistic-model

--- a/services/vision_service/src/api/main.py
+++ b/services/vision_service/src/api/main.py
@@ -1,3 +1,4 @@
+from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from prometheus_client import make_asgi_app
@@ -46,9 +47,9 @@ async def root():
     }
 
 
-@app.on_event("startup")
-async def startup_event():
-    """Evento al iniciar la aplicación"""
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Evento de ciclo de vida de la aplicación."""
     print("=" * 60)
     print("SignSpeak Vision API - Starting")
     print("=" * 60)
@@ -67,9 +68,7 @@ async def startup_event():
     print("API ready!")
     print("Docs: http://localhost:8000/docs")
     print("=" * 60)
-
-
-@app.on_event("shutdown")
-async def shutdown_event():
-    """Evento al cerrar la aplicación"""
+    
+    yield
+    
     print("SignSpeak Vision API - Shutting down")

--- a/services/vision_service/src/api/main.py
+++ b/services/vision_service/src/api/main.py
@@ -1,4 +1,5 @@
 from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from prometheus_client import make_asgi_app
@@ -68,7 +69,7 @@ async def lifespan(app: FastAPI):
     print("API ready!")
     print("Docs: http://localhost:8000/docs")
     print("=" * 60)
-    
+
     yield
-    
+
     print("SignSpeak Vision API - Shutting down")

--- a/tests/integration/test_media_pipeline.py
+++ b/tests/integration/test_media_pipeline.py
@@ -35,12 +35,15 @@ def client_with_mock():
 
 def test_translate_video_endpoint(client_with_mock):
     """Test /media/translate/video endpoint with mocked processor."""
-    # Create dummy video file content (not a real video, but bytes)
-    # The mock processor accepts any bytes
+    # Mock for continuous mode which is the default
+    mock_processor.process_video_sliding_window.return_value = [
+        {"start_time": 0, "end_time": 1, "features": np.zeros(226)}
+    ]
+    
     video_content = b"fake-video-content"
-
     response = client_with_mock.post(
         "/api/v1/media/translate/video",
+        data={"mode": "continuous"},
         files={"file": ("test.mp4", video_content, "video/mp4")},
     )
 
@@ -55,7 +58,7 @@ def test_translate_video_endpoint(client_with_mock):
     assert data["frames_processed"] == 30
 
     # Verify mock was called
-    mock_processor.process_video_bytes.assert_called_once()
+    mock_processor.process_video_sliding_window.assert_called_once()
 
 
 def test_translate_video_invalid_file_type(client_with_mock):

--- a/tests/integration/test_media_pipeline.py
+++ b/tests/integration/test_media_pipeline.py
@@ -39,7 +39,7 @@ def test_translate_video_endpoint(client_with_mock):
     mock_processor.process_video_sliding_window.return_value = [
         {"start_time": 0, "end_time": 1, "features": np.zeros(226)}
     ]
-    
+
     video_content = b"fake-video-content"
     response = client_with_mock.post(
         "/api/v1/media/translate/video",

--- a/tests/unit/api_gateway/test_api_gateway.py
+++ b/tests/unit/api_gateway/test_api_gateway.py
@@ -165,8 +165,11 @@ class TestBufferManagementEndpoints:
     def test_get_buffer_stats(self, gateway_client, mock_vision_client):
         """Obtener estadísticas del buffer."""
         mock_vision_client["get_word_buffer_stats"].return_value = {
-            "buffer_size": 10,
-            "phrase_length": 3,
+            "total_received": 15,
+            "total_accepted": 3,
+            "rejected_by_cooldown": 5,
+            "rejected_by_confidence": 7,
+            "acceptance_rate": 20.0,
             "current_phrase": "hola mundo adios",
         }
 
@@ -174,8 +177,8 @@ class TestBufferManagementEndpoints:
 
         assert response.status_code == 200
         data = response.json()
-        assert data["buffer_size"] == 10
-        assert data["phrase_length"] == 3
+        assert data["total_received"] == 15
+        assert data["total_accepted"] == 3
 
     def test_clear_word_buffer(self, gateway_client, mock_vision_client):
         """Limpiar buffer de palabras."""

--- a/tests/unit/translation_service/test_translation.py
+++ b/tests/unit/translation_service/test_translation.py
@@ -1,7 +1,9 @@
+import os
+import sys
+
 import pytest
 from fastapi.testclient import TestClient
-import sys
-import os
+
 
 @pytest.fixture
 def translation_client():
@@ -9,15 +11,18 @@ def translation_client():
     for key in list(sys.modules.keys()):
         if key.startswith("src.") or key == "src":
             del sys.modules[key]
-            
+
     # Add the translation service path precisely
-    target_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../services/translation_service"))
+    target_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "../../../services/translation_service")
+    )
     sys.path.insert(0, target_path)
-    
+
     from src.main import app
+
     client = TestClient(app)
     yield client
-    
+
     # Cleanup to not pollute other tests
     if target_path in sys.path:
         sys.path.remove(target_path)
@@ -25,14 +30,14 @@ def translation_client():
         if key.startswith("src.") or key == "src":
             del sys.modules[key]
 
+
 class TestTranslationEndpoint:
     """Tests para /api/v1/translate/."""
 
     def test_translate_text_success(self, translation_client):
         """Traducción de texto exitosa."""
         response = translation_client.post(
-            "/api/v1/translate/",
-            json={"text": "hola mundo"}
+            "/api/v1/translate/", json={"text": "hola mundo"}
         )
         assert response.status_code == 200
         data = response.json()
@@ -42,8 +47,7 @@ class TestTranslationEndpoint:
     def test_translate_video_url_success(self, translation_client):
         """Traducción de video_url exitosa."""
         response = translation_client.post(
-            "/api/v1/translate/",
-            json={"video_url": "http://example.com/video.mp4"}
+            "/api/v1/translate/", json={"video_url": "http://example.com/video.mp4"}
         )
         assert response.status_code == 200
         data = response.json()
@@ -53,18 +57,14 @@ class TestTranslationEndpoint:
     def test_translate_missing_info(self, translation_client):
         """Traducción falla sin texto ni video."""
         response = translation_client.post(
-            "/api/v1/translate/",
-            json={"text": "", "video_url": ""} # Empty fields
+            "/api/v1/translate/", json={"text": "", "video_url": ""}  # Empty fields
         )
         assert response.status_code == 422
         assert "Debes enviar text o video_url" in response.json()["detail"]
 
     def test_translate_empty_body(self, translation_client):
         """Traducción falla si el body no tiene la estructura requerida."""
-        response = translation_client.post(
-            "/api/v1/translate/",
-            json={} # Empty json
-        )
+        response = translation_client.post("/api/v1/translate/", json={})  # Empty json
         # Assuming Pydantic catches missing fields or TranslateRequest allows optional fields
         # If both are optional, our custom 422 triggers
         # Let's just assert it is 422

--- a/tests/unit/translation_service/test_translation.py
+++ b/tests/unit/translation_service/test_translation.py
@@ -1,0 +1,71 @@
+import pytest
+from fastapi.testclient import TestClient
+import sys
+import os
+
+@pytest.fixture
+def translation_client():
+    # Remove any existing cached 'src' modules from other test collections
+    for key in list(sys.modules.keys()):
+        if key.startswith("src.") or key == "src":
+            del sys.modules[key]
+            
+    # Add the translation service path precisely
+    target_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../services/translation_service"))
+    sys.path.insert(0, target_path)
+    
+    from src.main import app
+    client = TestClient(app)
+    yield client
+    
+    # Cleanup to not pollute other tests
+    if target_path in sys.path:
+        sys.path.remove(target_path)
+    for key in list(sys.modules.keys()):
+        if key.startswith("src.") or key == "src":
+            del sys.modules[key]
+
+class TestTranslationEndpoint:
+    """Tests para /api/v1/translate/."""
+
+    def test_translate_text_success(self, translation_client):
+        """Traducción de texto exitosa."""
+        response = translation_client.post(
+            "/api/v1/translate/",
+            json={"text": "hola mundo"}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "Traducción de: hola mundo" in data["text"]
+        assert data["confidence"] == 0.93
+
+    def test_translate_video_url_success(self, translation_client):
+        """Traducción de video_url exitosa."""
+        response = translation_client.post(
+            "/api/v1/translate/",
+            json={"video_url": "http://example.com/video.mp4"}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["text"] == "[ML] Hola, ¿cómo estás?"
+        assert data["confidence"] == 0.95
+
+    def test_translate_missing_info(self, translation_client):
+        """Traducción falla sin texto ni video."""
+        response = translation_client.post(
+            "/api/v1/translate/",
+            json={"text": "", "video_url": ""} # Empty fields
+        )
+        assert response.status_code == 422
+        assert "Debes enviar text o video_url" in response.json()["detail"]
+
+    def test_translate_empty_body(self, translation_client):
+        """Traducción falla si el body no tiene la estructura requerida."""
+        response = translation_client.post(
+            "/api/v1/translate/",
+            json={} # Empty json
+        )
+        # Assuming Pydantic catches missing fields or TranslateRequest allows optional fields
+        # If both are optional, our custom 422 triggers
+        # Let's just assert it is 422
+        assert response.status_code == 422


### PR DESCRIPTION
This PR includes the stabilization for the CI/CD pipeline and test suite:
- **Tests fixes:** Fixed API Gateway missing prediction endpoints tests and media pipeline mocks.
- **Refactor:** Migrated FastAPI from deprecated `on_event` to `lifespan` in Vision Service.
- **CI Hardening:** Re-enabled strict test checking and fixed `pytest.ini` invalid options.