### PR TITLE
Corrección: Instalación de Dependencias para Tests de SonarCloud

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -20,7 +20,9 @@ jobs:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: pip install -r requirements-dev.txt
+        run: |
+          pip install -r requirements-dev.txt
+          find services -name "requirements.txt" -exec pip install -r {} +
 
       - name: Run tests with coverage
         run: |
@@ -28,6 +30,8 @@ jobs:
             --cov=services \
             --cov-report=xml:coverage.xml \
             -v
+        env:
+          PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/services/api_gateway:${{ github.workspace }}/services/vision_service/src:${{ github.workspace }}/services/translation_service
         continue-on-error: true
 
       - name: SonarCloud Scan

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements-dev.txt
-          find services -name "requirements.txt" -exec pip install -r {} +
+          pip install -r services/api_gateway/requirements.txt
+          pip install -r services/translation_service/requirements.txt
+          pip install -r services/vision_service/requirements.txt
 
       - name: Run tests with coverage
         run: |


### PR DESCRIPTION
Este PR corrige el error de "ModuleNotFoundError: No module named 'fastapi'" en el workflow de SonarCloud instalando todas las dependencias de los servicios y configurando el PYTHONPATH correctamente para los tests.